### PR TITLE
Fix Gitignore on VSCode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,8 @@ cmake-build-*/
 .idea/**/libraries
 
 # ONLY VS Code build dir
-build/
-!/mbed-os/**/
+/build/
+
 
 # VS Code config files
 .vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -35,8 +35,6 @@ cmake-build-*/
 # Python stuff
 *.pyc
 
-# Python Virtual ENVironment
-mbed-os/venv
 
 # Mac stuff
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,6 @@ cmake-build-*/
 # Python stuff
 *.pyc
 
-
 # Mac stuff
 .DS_Store
 

--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,6 @@ cmake-build-*/
 # ONLY VS Code build dir
 /build/
 
-
 # VS Code config files
 .vscode/
 

--- a/.gitignore
+++ b/.gitignore
@@ -26,8 +26,9 @@ cmake-build-*/
 .idea/**/gradle.xml
 .idea/**/libraries
 
-# VS Code build dir
+# ONLY VS Code build dir
 build/
+!/mbed-os/**/
 
 # VS Code config files
 .vscode/
@@ -35,5 +36,9 @@ build/
 # Python stuff
 *.pyc
 
+# Python Virtual ENVironment
+mbed-os/venv
+
 # Mac stuff
 .DS_Store
+


### PR DESCRIPTION
### A few problems in the gitignore file:

1. Build/
There is a build folder within the mbed-os folder (/mbed-os/tools/python/mbed_tools/build). Currently the OS folder is missing that build folder. 

### Suggested Correction:

1. /Build/
To make sure that the ONLY the top-level vs-code build folder is ignored.

### Suggested Addition:

1. mbed-os/venv
The Virtual ENVironment folder needs to be deleted usually after the build process is messed up. To make github action potentially more user-friendly, we may make sure that no /venv folder exist in the remote repo so that the /venv folder is regenerated every time a commit is pushed.